### PR TITLE
post image router 추가

### DIFF
--- a/src/__test__/image.spec.ts
+++ b/src/__test__/image.spec.ts
@@ -3,17 +3,18 @@ import { expect } from "chai";
 
 import { app } from "../app";
 
-describe("Image Routers", () => {
-  describe("GET /presigned_post: get presinged post", () => {
+describe("Post Image Routers", () => {
+  describe("GET /:id/images/presigned_post: get presinged post", () => {
     context("When user requests", () => {
       it("should return presigned post", async () => {
         return request(app)
-          .get("/images/presigned_post")
+          .get("/posts/asdf/images/presigned_post")
           .query({ fileName: "image", fileType: "png" })
           .expect(200)
           .then((response) => {
             expect(response.body).has.property("url");
             expect(response.body).has.property("fields");
+            expect(response.body.fields.key).to.be.eq("/posts/asdf/image.png");
           })
           .catch((error) => {
             throw error;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
 
-import { applyImageRouters } from "./routers/image";
+import { applyPostImageRouters } from "./routers/post";
 import { applyErrorHandlers } from "./errorHandlers";
 
 export const getRootRouter = () => {
   const router = Router();
 
-  applyImageRouters(router);
+  applyPostImageRouters(router);
   applyErrorHandlers(router);
 
   return router;

--- a/src/api/routers/post.ts
+++ b/src/api/routers/post.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { query } from "express-validator";
+import { param, query } from "express-validator";
 
 import { validateParameters } from "../middlewares/validateParameters";
 
@@ -7,20 +7,24 @@ import * as Presenters from "../presenters";
 
 import { PresignedPostGenerator } from "../services/presignedPostGenerator";
 
-export const applyImageRouters = (rootRouter: Router) => {
+export const applyPostImageRouters = (rootRouter: Router) => {
   const router = Router();
 
   router.get(
-    "/presigned_post",
+    "/:id/images/presigned_post",
+    param("id").isString().exists(),
     query("fileName").isString().exists(),
     query("fileType").isString().exists(),
     validateParameters,
     async (req, res, next) => {
       try {
+        const postId = req.params.id as string;
         const fileName = req.query.fileName as string;
         const fileType = req.query.fileType as string;
 
-        const presignedPost = await new PresignedPostGenerator(fileName, fileType).generate();
+        const key = `/posts/${postId}/${fileName}.${fileType}`;
+
+        const presignedPost = await new PresignedPostGenerator(key).generate();
 
         return res.status(200).json(Presenters.presentPresignedPost(presignedPost));
       } catch (error) {
@@ -29,5 +33,5 @@ export const applyImageRouters = (rootRouter: Router) => {
     }
   );
 
-  rootRouter.use("/images", router);
+  rootRouter.use("/posts", router);
 };

--- a/src/api/services/presignedPostGenerator.ts
+++ b/src/api/services/presignedPostGenerator.ts
@@ -4,23 +4,19 @@ import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
 export class PresignedPostGenerator {
   private client: S3Client;
 
-  constructor(private fileName: string, private fileType: string) {
+  constructor(private key: string) {
     this.client = new S3Client({ region: process.env.REGION! });
   }
 
   public async generate() {
     return await createPresignedPost(this.client, {
       Bucket: process.env.BUCKET!,
-      Key: `${this.fileName}.${this.fileType}`,
+      Key: this.key,
       Expires: 120,
       Fields: {
-        key: `${this.fileName}.${this.fileType}`,
-        "Content-Type": `image/${this.fileType}`,
+        key: this.key,
       },
-      Conditions: [
-        ["eq", "$key", `${this.fileName}.${this.fileType}`],
-        ["starts-with", "$Content-Type", "image/"],
-      ],
+      Conditions: [["eq", "$key", this.key]],
     });
   }
 }


### PR DESCRIPTION
이미지가 어떤 포스트에 속해있는지 트래킹하기 위해, 기존의 image router를 삭제하고 post image router를 추가합니다.

S3 업로드 key가 /posts/${postId}/${fileName}.${fileType} 형태로 변경됩니다.